### PR TITLE
Add output languages ECMAScript5 and ECMAScript6

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Options:
 The currently supported languages are
 * CoffeeScript (coffeescript) [default]
 * C# (csharp)
+* ECMAScript5 (javascript)
+* ECMAScript6 (javascript2.0)
 * Java (java)
 * PHP (php)
 * Ruby (ruby)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Brian Folts <brian.folts@gmail.com>",
   "main": "plantcode",
   "scripts": {
-    "test": "node plantcode -l csharp tests/car.pegjs > tests/car.cs && node plantcode -l java tests/car.pegjs > tests/car.java && node plantcode -l coffeescript tests/car.pegjs > tests/car.coffee && node plantcode -l typescript tests/car.pegjs > tests/car.ts && node plantcode -l ruby tests/car.pegjs > tests/car.rb && node plantcode -l php tests/car.pegjs > tests/car.php"
+    "test": "node plantcode -l csharp tests/car.pegjs > tests/car.cs && node plantcode -l java tests/car.pegjs > tests/car.java && node plantcode -l coffeescript tests/car.pegjs > tests/car.coffee && node plantcode -l typescript tests/car.pegjs > tests/car.ts && node plantcode -l ruby tests/car.pegjs > tests/car.rb && node plantcode -l php tests/car.pegjs > tests/car.php && node plantcode -l ecmascript5 tests/car.pegjs > tests/car.js && node plantcode -l ecmascript6 tests/car.pegjs > tests/car.js6"
   },
   "bin": "plantcode",
   "repository": {

--- a/plantcode
+++ b/plantcode
@@ -10,7 +10,7 @@ var options = {
   output: null
 };
 
-var supported_languages = ["coffeescript", "csharp", "java", "php", "ruby", "typescript"];
+var supported_languages = ["coffeescript", "csharp", "ecmascript5", "ecmascript6", "java", "php", "ruby", "typescript"];
 
 var args = process.argv.slice(2); // Trim "node" and the script path.
 
@@ -161,3 +161,23 @@ function processTemplateFile(templateData, dictionary) {
   }
 
 }
+
+// Workaround for an apparent bug in Handlebars: functions are not called with the parent scope
+// as context.
+//
+// Here the getFullName is found in the parent scope (Class), but it is called with the current
+// scope (Field) as context:
+//
+// {{#each getFields}}
+//   {{../getFullName}}
+// {{/each}}
+//
+// The following helper works around it:
+//
+// {{#each getFields}}
+//   {{#call ../this ../getFullName}}
+// {{/each}}
+
+hbs.registerHelper('call', function (context, member, options) {
+   return member.call(context);
+});

--- a/src/Class.js
+++ b/src/Class.js
@@ -35,6 +35,15 @@ module.exports = (function () {
     return this.className;
   }
  
+  Class.prototype.hasMethods = function () {
+    for (var i = 0, length = this.fileLines.length; i < length; i++) {
+      if (this.fileLines[i] instanceof Method) {
+        return true;
+      }
+    }
+    return false;
+  }
+ 
   Class.prototype.getMethods = function () {
     var aResult = [];
     for (var i = 0, length = this.fileLines.length; i < length; i++) {
@@ -43,6 +52,15 @@ module.exports = (function () {
       }
     }
     return aResult;
+  }
+ 
+  Class.prototype.hasFields = function () {
+    for (var i = 0, length = this.fileLines.length; i < length; i++) {
+      if (!(this.fileLines[i] instanceof Method) && this.fileLines[i] instanceof Field) {
+        return true;
+      }
+    }
+    return false;
   }
  
   Class.prototype.getFields = function () {

--- a/templates/ecmascript5.hbs
+++ b/templates/ecmascript5.hbs
@@ -1,0 +1,15 @@
+{{#if getExtends}}
+  function {{getFullName}}() {
+    {{#with getExtends}}{{getFullName}}{{/with}}.prototype.constructor.apply(this, arguments);
+  }
+  {{getFullName}}.prototype = Object.create({{#with getExtends}}{{getFullName}}{{/with}}.prototype);
+  {{getFullName}}.prototype.constructor = {{getFullName}};
+{{else}}
+  function {{getFullName}}() {}
+{{/if}}
+{{#each getFields}}
+  {{#call ../this ../getFullName}}{{/call}}.prototype.{{getName}} = undefined;
+{{/each}}
+{{#each getMethods}}
+  {{#call ../this ../getFullName}}{{/call}}.prototype.{{getName}} = function ({{#if getParameters}}{{#each getParameters}}{{#if @first}}{{else}},{{/if}}{{#if getName}}{{getName}}{{else}}param{{@index}}{{/if}}{{/each}}{{/if}}) {};
+{{/each}}

--- a/templates/ecmascript6.hbs
+++ b/templates/ecmascript6.hbs
@@ -1,0 +1,23 @@
+class {{getFullName}}{{#if getExtends}} extends {{#with getExtends}}{{getFullName}}{{/with}}{{/if}} {
+{{#if getExtends}}
+ {{#if hasFields}}
+  constructor: function () {
+    super().apply(this, arguments);
+   {{#each getFields}}
+    this.{{getName}} = undefined;
+   {{/each}}
+  }{{#if hasMethods}},{{/if}}
+ {{/if}}
+{{else}}
+ {{#if hasFields}}
+  constructor: function () {
+   {{#each getFields}}
+    this.{{getName}} = undefined;
+   {{/each}}
+  }{{#if hasMethods}},{{/if}}
+ {{/if}}
+{{/if}}
+{{#each getMethods}}
+  {{getName}}: function ({{#if getParameters}}{{#each getParameters}}{{#if @first}}{{else}},{{/if}}{{#if getName}}{{getName}}{{else}}param{{@index}}{{/if}}{{/each}}{{/if}}) {}{{#if @last}}{{else}},{{/if}}
+{{/each}}
+}

--- a/tests/car.js
+++ b/tests/car.js
@@ -1,0 +1,30 @@
+  function Car() {}
+  Car.prototype.model = undefined;
+  Car.prototype.make = undefined;
+  Car.prototype.year = undefined;
+  Car.prototype.setModel = function (model) {};
+  Car.prototype.setMake = function (make) {};
+  Car.prototype.setYear = function (param0) {};
+  Car.prototype.getModel = function () {};
+  Car.prototype.getMake = function () {};
+  Car.prototype.getYear = function () {};
+
+  function Toyota() {
+    Car.prototype.constructor.apply(this, arguments);
+  }
+  Toyota.prototype = Object.create(Car.prototype);
+  Toyota.prototype.constructor = Toyota;
+
+  function Honda() {
+    Car.prototype.constructor.apply(this, arguments);
+  }
+  Honda.prototype = Object.create(Car.prototype);
+  Honda.prototype.constructor = Honda;
+
+  function Ford() {
+    Car.prototype.constructor.apply(this, arguments);
+  }
+  Ford.prototype = Object.create(Car.prototype);
+  Ford.prototype.constructor = Ford;
+
+

--- a/tests/car.js6
+++ b/tests/car.js6
@@ -1,0 +1,24 @@
+class Car {
+  constructor: function () {
+    this.model = undefined;
+    this.make = undefined;
+    this.year = undefined;
+  },
+  setModel: function (model) {},
+  setMake: function (make) {},
+  setYear: function (param0) {},
+  getModel: function () {},
+  getMake: function () {},
+  getYear: function () {}
+}
+
+class Toyota extends Car {
+}
+
+class Honda extends Car {
+}
+
+class Ford extends Car {
+}
+
+


### PR DESCRIPTION
Add Handlebars templates with the current features for the new languages.
Generate test files for the new languages.
Work around a problem with using object methods instead of attributes in Handlebars.
Add hasMethods and hasFields methods to Class to be able to omit code blocks entirely.