### PR TITLE
Richer class names and introduction of "classtypes"

### DIFF
--- a/plantcode
+++ b/plantcode
@@ -179,6 +179,7 @@ function processTemplateFile(config, templateData, dictionary) {
          "getKeyword": true,
          "getMethods": true,
          "getName": true,
+         "getType": true,
          "getParameters": true,
          "getReturnType": true,
          "hasFields": true,

--- a/src/Class.js
+++ b/src/Class.js
@@ -4,10 +4,11 @@ module.exports = (function () {
   var Field = require("./Field");
   var Method = require("./Method");
 
-  var Class = function (className, fileLines) {
+  var Class = function (className, fileLines, classType) {
     this.cExtends = null;
     this.fileLines = fileLines || [];
     this.className = className;
+    this.classType = classType || "";
     this.nNamespace = null;
   }
 
@@ -37,6 +38,10 @@ module.exports = (function () {
 
   Class.prototype.getName = function () {
     return this.className;
+  }
+ 
+  Class.prototype.getType = function () {
+    return this.classType;
   }
  
   Class.prototype.hasMethods = function () {

--- a/src/plantcode.js
+++ b/src/plantcode.js
@@ -73,6 +73,7 @@ function processTemplateFile(config, templateData, dictionary) {
          "getKeyword": true,
          "getMethods": true,
          "getName": true,
+         "getType": true,
          "getParameters": true,
          "getReturnType": true,
          "hasFields": true,

--- a/src/plantuml.js
+++ b/src/plantuml.js
@@ -179,16 +179,20 @@ module.exports = (function() {
         peg$c140 = /^[^ ,\n\r\t(){}]/,
         peg$c141 = { type: "class", value: "[^ ,\\n\\r\\t(){}]", description: "[^ ,\\n\\r\\t(){}]" },
         peg$c142 = function(items) { return items.join("") },
-        peg$c143 = /^[A-Za-z_]/,
-        peg$c144 = { type: "class", value: "[A-Za-z_]", description: "[A-Za-z_]" },
-        peg$c145 = /^[A-Za-z0-9.]/,
-        peg$c146 = { type: "class", value: "[A-Za-z0-9.]", description: "[A-Za-z0-9.]" },
-        peg$c147 = function(objectname) { return [objectname[0], objectname[1].join("")].join("") },
+        peg$c143 = function(item) { return item.join("") },
+        peg$c144 = "\"",
+        peg$c145 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c146 = /^[A-Za-z_]/,
+        peg$c147 = { type: "class", value: "[A-Za-z_]", description: "[A-Za-z_]" },
         peg$c148 = /^[A-Za-z0-9_]/,
         peg$c149 = { type: "class", value: "[A-Za-z0-9_]", description: "[A-Za-z0-9_]" },
         peg$c150 = function(items) { return [items[0], items[1].join("")].join("") },
         peg$c151 = /^[+]/,
         peg$c152 = { type: "class", value: "[+]", description: "[+]" },
+        peg$c153 = /^[A-Za-z0-9_:;~#!\xA7$()[\]+\-*\\\/|,]/,
+        peg$c154 = { type: "class", value: "[A-Za-z0-9_:;~#!\xA7$()\\[\\]\\+\\-\\*\\\\/|,]", description: "[A-Za-z0-9_:;~#!\xA7$()\\[\\]\\+\\-\\*\\\\/|,]" },
+        peg$c155 = /^[A-Za-z0-9_:;~#!\xA7$()[\]+\-*\\\/|,{} ]/,
+        peg$c156 = { type: "class", value: "[A-Za-z0-9_:;~#!\xA7$()\\[\\]\\+\\-\\*\\\\/|,{} ]", description: "[A-Za-z0-9_:;~#!\xA7$()\\[\\]\\+\\-\\*\\\\/|,{} ]" },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -3472,52 +3476,51 @@ module.exports = (function() {
     }
 
     function peg$parseobjectname() {
-      var s0, s1, s2, s3, s4;
+      var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      s1 = peg$currPos;
-      if (peg$c143.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = [];
-        if (peg$c145.test(input.charAt(peg$currPos))) {
-          s4 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c146); }
-        }
-        while (s4 !== peg$FAILED) {
-          s3.push(s4);
-          if (peg$c145.test(input.charAt(peg$currPos))) {
-            s4 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c146); }
-          }
-        }
-        if (s3 !== peg$FAILED) {
-          s2 = [s2, s3];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
+      s1 = peg$parserichchars();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c147(s1);
+        s1 = peg$c143(s1);
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 34) {
+          s1 = peg$c144;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c145); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsericherchars();
+          if (s2 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 34) {
+              s3 = peg$c144;
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c145); }
+            }
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c143(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       return s0;
     }
@@ -3527,12 +3530,12 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (peg$c143.test(input.charAt(peg$currPos))) {
+      if (peg$c146.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c144); }
+        if (peg$silentFails === 0) { peg$fail(peg$c147); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -3624,6 +3627,64 @@ module.exports = (function() {
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      }
+
+      return s0;
+    }
+
+    function peg$parserichchars() {
+      var s0, s1;
+
+      s0 = [];
+      if (peg$c153.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
+      }
+      if (s1 !== peg$FAILED) {
+        while (s1 !== peg$FAILED) {
+          s0.push(s1);
+          if (peg$c153.test(input.charAt(peg$currPos))) {
+            s1 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c154); }
+          }
+        }
+      } else {
+        s0 = peg$FAILED;
+      }
+
+      return s0;
+    }
+
+    function peg$parsericherchars() {
+      var s0, s1;
+
+      s0 = [];
+      if (peg$c155.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c156); }
+      }
+      if (s1 !== peg$FAILED) {
+        while (s1 !== peg$FAILED) {
+          s0.push(s1);
+          if (peg$c155.test(input.charAt(peg$currPos))) {
+            s1 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c156); }
+          }
+        }
+      } else {
+        s0 = peg$FAILED;
       }
 
       return s0;

--- a/src/plantuml.pegjs
+++ b/src/plantuml.pegjs
@@ -79,10 +79,9 @@ newline
   = [\r\n]
   / [\n]
 classdeclaration
-  = noise "class " noise classname:objectname noise startblock lines:umllines endblock { var Class = require("./Class"); return new Class(classname, lines) }
-  / noise "class " noise classname:objectname noise "<<" noise [^>]+ noise ">>" noise { var Class = require("./Class"); return new Class(classname) }
-  / noise "class " noise classname:objectname noise { var Class = require("./Class"); return new Class(classname) }
-  / noise "class " noise classname:objectname noise newline noise lines:umllines "end class" { var Class = require("./Class"); return new Class(classname, lines) }
+  = noise "class " noise classname:objectname noise classtype:objecttype? noise startblock lines:umllines endblock       { var Class = require("./Class"); return new Class(classname, lines, classtype) }
+  / noise "class " noise classname:objectname noise classtype:objecttype? noise                                          { var Class = require("./Class"); return new Class(classname, null, classtype) }
+  / noise "class " noise classname:objectname noise classtype:objecttype? noise newline noise lines:umllines "end class" { var Class = require("./Class"); return new Class(classname, lines, classtype) }
 interfacedeclaration
   = noise "interface " noise interfacename:objectname noise startblock lines:umllines endblock { var Interface = require("./Interface"); return new Interface(interfacename, lines) }
   / noise "interface " noise interfacename:objectname noise "<<" noise [^>]+ noise ">>" noise { var Interface = require("./Interface"); return new Interface(interfacename) }
@@ -113,6 +112,8 @@ returntype
 objectname
   = item:(richchars) { return item.join("") }
   / "\"" item:(richerchars) "\"" { return item.join("") }
+objecttype
+  = "<<" noise item:(richerchars) noise ">>" { return item.join("") }
 membername
   = items:([A-Za-z_][A-Za-z0-9_]*) { return [items[0], items[1].join("")].join("") }
 accessortype

--- a/src/plantuml.pegjs
+++ b/src/plantuml.pegjs
@@ -111,7 +111,8 @@ methodparameter
 returntype
   = items:[^ ,\n\r\t(){}]+ { return items.join("") }
 objectname
-  = objectname:([A-Za-z_][A-Za-z0-9.]*) { return [objectname[0], objectname[1].join("")].join("") }
+  = item:(richchars) { return item.join("") }
+  / "\"" item:(richerchars) "\"" { return item.join("") }
 membername
   = items:([A-Za-z_][A-Za-z0-9_]*) { return [items[0], items[1].join("")].join("") }
 accessortype
@@ -124,3 +125,7 @@ privateaccessor
   = [-]
 protectedaccessor
   = [#]
+richchars
+  = [A-Za-z0-9_:;~#!§$()\[\]\+\-\*\\/|,]+
+richerchars
+  = [A-Za-z0-9_:;~#!§$()\[\]\+\-\*\\/|,{} ]+

--- a/templates/coffeescript.hbs
+++ b/templates/coffeescript.hbs
@@ -1,4 +1,5 @@
 {{#if_ne getKeyword "interface"}}class {{getFullName}}{{#if getExtends}} extends {{#with getExtends}}{{getFullName}}{{/with}}{{/if}}
+{{#if getType}}# was typed as <<{{getType}}>>{{/if}}
 {{#each getFields}}
   {{this.getName}}: undefined
 {{/each}}

--- a/tests/complex/classnames.coffee
+++ b/tests/complex/classnames.coffee
@@ -2,7 +2,9 @@ class someclass
 
 
 
+
 class §$noQuotes|_:;~#!§$()[]+-*\/,|
+
 
 
 
@@ -10,7 +12,19 @@ class inQuotes
 
 
 
+
 class AZaz09 |_:;~#!§$()[]+-*\/,{}|
+
+
+
+
+class withDescr1
+# was typed as <<something>>
+
+
+
+class withDescr2
+# was typed as <<some { } thing>>
 
 
 

--- a/tests/complex/classnames.coffee
+++ b/tests/complex/classnames.coffee
@@ -1,0 +1,17 @@
+class someclass
+
+
+
+class §$noQuotes|_:;~#!§$()[]+-*\/,|
+
+
+
+class inQuotes
+
+
+
+class AZaz09 |_:;~#!§$()[]+-*\/,{}|
+
+
+
+

--- a/tests/complex/classnames.plantuml
+++ b/tests/complex/classnames.plantuml
@@ -2,8 +2,7 @@
 ' node node_modules/pegjs/bin/pegjs src/plantuml.pegjs src/plantuml.js
 ' node plantcode -l coffeescript tests/complex/classnames.plantuml > tests/complex/classnames.coffee
 
-class someclass {
-}
+class someclass
 
 class §$noQuotes|_:;~#!§$()[]+-*\/,| {
 }
@@ -12,6 +11,11 @@ class "inQuotes" {
 }
 
 class "AZaz09 |_:;~#!§$()[]+-*\/,{}|" {
+}
+
+class "withDescr1" <<something>>
+
+class "withDescr2" <<some { } thing>> {
 }
 
 @enduml

--- a/tests/complex/classnames.plantuml
+++ b/tests/complex/classnames.plantuml
@@ -1,0 +1,17 @@
+@startuml
+' node node_modules/pegjs/bin/pegjs src/plantuml.pegjs src/plantuml.js
+' node plantcode -l coffeescript tests/complex/classnames.plantuml > tests/complex/classnames.coffee
+
+class someclass {
+}
+
+class §$noQuotes|_:;~#!§$()[]+-*\/,| {
+}
+
+class "inQuotes" {
+}
+
+class "AZaz09 |_:;~#!§$()[]+-*\/,{}|" {
+}
+
+@enduml


### PR DESCRIPTION
Currently the system is VERY restricted about which classnames are allowed.
This will allow a lot of characters and allows to have the classname in quotes:

![image](https://user-images.githubusercontent.com/861649/95899601-19d8f500-0d91-11eb-9010-df7fb5aa3af4.png)

```
class someclass {}
class §$noQuotes|_:;~#!§$()[]+-*\/,| {}
class "inQuotes" {}
class "AZaz09 |_:;~#!§$()[]+-*\/,{}|" {}
```